### PR TITLE
Blog投稿を取得しTopページに表示する

### DIFF
--- a/welcart_basic-child/assets/css/blog.css
+++ b/welcart_basic-child/assets/css/blog.css
@@ -61,6 +61,7 @@
     overflow: hidden;
     border-radius: 12px 12px 0 12px;
     background-color: #d9d9d9;
+    object-fit: cover;
   }
 
   .Blog__more {

--- a/welcart_basic-child/front-page.php
+++ b/welcart_basic-child/front-page.php
@@ -412,27 +412,30 @@ button {
       <p class="Blog__summary">インターナショナルスクール・英会話教室</p>
 
       <div class="Blog__contents">
-        <div class="Blog__column">
-          <div class="Blog__columnItem">
-            <img src="https://dummyimage.com/119x88/f27d53/fff.png" width="119" height="88" alt="" loading="lazy" class="Blog__columnItemImage" />
-          </div>
+        <?php
+          $args = array(
+            'post_type' => 'blog',// 投稿タイプのスラッグを指定
+            'posts_per_page' => 2, // 投稿件数の指定 TODO: SMP: 2 PC: 4
+          );
+          $blog_query = new WP_Query($args); if($blog_query->have_posts()):
+        ?>
+        <?php while ($blog_query->have_posts()): $blog_query->the_post(); ?>
+          <a href="<?php the_permalink(); ?>" class="Blog__column">
+            <div class="Blog__columnItem">
+              <img src="<?php the_post_thumbnail_url();?>" width="119" height="88" alt="" loading="lazy" class="Blog__columnItemImage" />
+            </div>
 
-          <div class="Blog__columnItem">
-            <time>2024/02/29</time>
-            <p>幼児・小学生】無料体験レッスンの募集をはじめまあああああ</p>
-          </div>
-        </div>
+            <div class="Blog__columnItem">
+              <time datetime="<?php the_time('Y-m-d'); ?>"><?php the_time('Y/m/d'); ?></time>
+              <p><?php echo get_the_title(); ?></p>
+            </div>
+          </a>
+        <?php endwhile; ?>
+        <?php wp_reset_postdata(); ?>
 
-         <div class="Blog__column">
-          <div class="Blog__columnItem">
-            <img src="https://dummyimage.com/119x88/f27d53/fff.png" width="119" height="88" alt="" loading="lazy" class="Blog__columnItemImage" />
-          </div>
-
-          <div class="Blog__columnItem">
-            <time>2024/02/29</time>
-            <p>幼児・小学生】無料体験レッスンの募集をはじめまあああああ</p>
-          </div>
-        </div>
+        <?php else: ?>
+          <p>まだ投稿がありません。</p>
+        <?php endif; ?>
       </div>
 
       <div class="Blog__more">

--- a/welcart_basic-child/functions.php
+++ b/welcart_basic-child/functions.php
@@ -7,6 +7,28 @@ function theme_enqueue_styles() {
 }
 add_action('wp_enqueue_scripts', 'theme_enqueue_styles');
 
+/* ---------- カスタム投稿タイプを追加 ---------- */
+function create_post_type_blog() {
+  register_post_type(
+    'blog', // URL
+    array(
+      'labels' => array(
+        'name' => 'Blog'
+      ),
+      'public' => true,
+      'has_archive' => true,
+      'supports' => array('title','editor','thumbnail','author'),
+      'show_in_rest' => true,
+    )
+  );
+}
+
+add_action( 'init', 'create_post_type_blog' );
+
+/*【表示カスタマイズ】アイキャッチ画像の有効化 */
+add_theme_support( 'post-thumbnails' );
+
+
 // CSS読み込み
 function add_styles() {
   $date = date("Y-m-d-h-i");


### PR DESCRIPTION

| WordPress | Code | View |
| --- | --- | --- |
| ![image](https://github.com/shidara/PacificEnglis/assets/8042336/1bfd8f14-7c3d-4d7e-95d5-3917f53871a3) | ![image](https://github.com/shidara/PacificEnglis/assets/8042336/4983c931-7e56-4663-b17e-77d8607070a1) | ![image](https://github.com/shidara/PacificEnglis/assets/8042336/b229cef0-32cc-488f-9c37-82e09985ce15) |

参考
functions.phpでカスタム投稿とカスタムタクソノミーを作成する方法｜WordPress特化型メディアサイト【WPWeb】 
https://wordpress-web.and-ha.com/summary-add-custom-post-type/
WordPress アイキャッチ画像の表示方法 - by Takumi Hirashima
https://hirashimatakumi.com/blog/1256.html
【初心者向け】WordPressでアイキャッチ画像を設定する方法 | wp.geek
https://wpmake.jp/contents/knowledge/post-thumbnail/
WordPressでサムネイル（アイキャッチ）画像を取得する方法 | ワードプレステーマTCD
https://tcd-theme.com/2022/08/wp-get-featured-image.html
WordPressでのお知らせ欄の作り方！オススメはプラグインなし ｜ プロテク
https://propagandes.info/wordpress-news/